### PR TITLE
I broke your go.mod. Sorry.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/sbreitf1/gpgutil master
 	github.com/sbreitf1/go-console v0.0.0-20191104080804-39a87ed68626
+	github.com/sbreitf1/gpgutil v0.2.1-0.20191114081004-a5fb92738508
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c // indirect
 )


### PR DESCRIPTION
If someone still has explicit GO111MODULE=on, then `go install` fails.