### PR TITLE
Move config into proper XDG directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/sbreitf1/go-console"
 	"github.com/sbreitf1/go-jcrypt"
 )
@@ -21,7 +23,17 @@ func getConfigDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(usr.HomeDir, ".gohome"), nil
+	oldPath := path.Join(usr.HomeDir, ".gohome")
+	newPath := path.Join(xdg.StateHome, "gohome")
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		fmt.Println("You need to move your config file to the new location. Please run:")
+		fmt.Printf("mkdir -p %s && mv %s %s\n", xdg.StateHome, oldPath, newPath)
+		os.Exit(1)
+	}
+
+	return newPath, nil
+
 }
 
 func GetMatrixConfig() (MatrixConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sbreitf1/gohome
 go 1.19
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/danielb42/goat v1.0.1
 	github.com/sbreitf1/go-console v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
@@ -20,6 +22,7 @@ github.com/sbreitf1/go-jcrypt v0.1.0/go.mod h1:MRBDXafctAiDBsnu3kbObbx0yL4irWP2k
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -30,6 +33,7 @@ golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIi
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.10.0 h1:3R7pNqamzBraeqj/Tj8qt1aQ2HpmlC+Cx/qL/7hn4/c=

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	argBreakTime  = appMain.Flag("break", "Ignore actual break time and take input like '00:45' instead").Short('b').String()
 	argReminder   = appMain.Flag("reminder", "Show desktop notification on target time").Short('r').Bool()
 	argVerbose    = appMain.Flag("verbose", "Print every single step").Short('v').Bool()
-	argDumpColors = appMain.Flag("dump-colors", "Populates ~/.gohome/colors.json with the current colors").Bool()
+	argDumpColors = appMain.Flag("dump-colors", "Populates $XDG_STATE_HOME/gohome/colors.json with the current colors").Bool()
 	currentState  EntryType
 )
 


### PR DESCRIPTION
This PR will check the old location and print a helpful message how to migrate, only if the old folder exists.
After migration, or for new users who never used the old location, this change should be invisible.

Example of the migration workflow: 
![Screenshot from 2023-07-31 15-09-12](https://github.com/sbreitf1/gohome/assets/2489598/d4f44679-4af7-4b01-9f2d-25920b433733)

This fixes #14 