### PR TITLE
Fix for new matrix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Util to show current worktime and possible leave times with Matrix integration.
 To download and install the utility execute the following commands:
 
 ```
-go install github.com/sbreitf1/gohome@v1.1.0
+go install github.com/sbreitf1/gohome@latest
 ```
 
 Now start it with `gohome` from command line.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/beevik/etree v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
+github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
 github.com/danielb42/goat v1.0.1 h1:4fCkONYX3el0GZQ6d6SvY6cXk1hlmqAbvDOlNQ1Vxtg=
 github.com/danielb42/goat v1.0.1/go.mod h1:2ohZJEdGWNB2AtlZhHX1n9ZUN+n90MV0DcYs1x5CDJM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/matrixfetch.go
+++ b/matrixfetch.go
@@ -61,16 +61,15 @@ type MatrixConfig struct {
 
 // DormaClient represents an authorized connection to Matrix.
 type MatrixClient struct {
-	config           MatrixConfig
-	httpClient       *http.Client
-	sessionID        string
-	rendermapToken   string
-	monthDataID      string
-	bookingID        string
-	lastVisitedPage  string
-	nextUniqueToken  string
-	nextViewState    string
-	jSessionIDCookie string
+	config          MatrixConfig
+	httpClient      *http.Client
+	sessionID       string
+	rendermapToken  string
+	monthDataID     string
+	bookingID       string
+	lastVisitedPage string
+	nextUniqueToken string
+	nextViewState   string
 }
 
 // NewDormaClient returns a logged in DormaClient.
@@ -135,12 +134,6 @@ func (c *MatrixClient) detectRedirectURI() error {
 		}
 		matrixVersionURL = "/" + parts[1]
 		verbosePrint("detected matrix url %q", matrixVersionURL)
-	}
-
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "JESSIONID" {
-			c.jSessionIDCookie = cookie.Value
-		}
 	}
 
 	return nil

--- a/matrixfetch.go
+++ b/matrixfetch.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/beevik/etree"
 )
 
 const (
@@ -59,15 +61,16 @@ type MatrixConfig struct {
 
 // DormaClient represents an authorized connection to Matrix.
 type MatrixClient struct {
-	config          MatrixConfig
-	httpClient      *http.Client
-	sessionID       string
-	rendermapToken  string
-	monthDataID     string
-	bookingID       string
-	lastVisitedPage string
-	nextUniqueToken string
-	nextViewState   string
+	config           MatrixConfig
+	httpClient       *http.Client
+	sessionID        string
+	rendermapToken   string
+	monthDataID      string
+	bookingID        string
+	lastVisitedPage  string
+	nextUniqueToken  string
+	nextViewState    string
+	jSessionIDCookie string
 }
 
 // NewDormaClient returns a logged in DormaClient.
@@ -125,7 +128,7 @@ func (c *MatrixClient) detectRedirectURI() error {
 		return err
 	}
 
-	if resp.StatusCode == 302 {
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		parts := strings.Split(resp.Header.Get("Location"), "/")
 		if len(parts) != 3 {
 			return fmt.Errorf("unexpected redirect url for login: %s", resp.Header.Get("Location"))
@@ -133,11 +136,18 @@ func (c *MatrixClient) detectRedirectURI() error {
 		matrixVersionURL = "/" + parts[1]
 		verbosePrint("detected matrix url %q", matrixVersionURL)
 	}
+
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "JESSIONID" {
+			c.jSessionIDCookie = cookie.Value
+		}
+	}
+
 	return nil
 }
 
 func (c *MatrixClient) visitSelfService() error {
-	requestBody := "uniqueToken=" + c.nextUniqueToken + "&autoScroll=&agmenuform_SUBMIT=1&javax.faces.ViewState=" + c.nextViewState + "&activateMenuItem=mss_root&menuIndex=4&agmenuform%3AassemblyGroupMenu=agmenuform%3AassemblyGroupMenu&data-matrix-treepath=mss_root&agmenuform%3AassemblyGroupMenu_menuid=4"
+	requestBody := "uniqueToken=" + c.nextUniqueToken + "&autoScroll=&agmenuform_SUBMIT=1&javax.faces.ViewState=" + c.nextViewState + "&activateMenuItem=mss_root&menuIndex=4&agmenuform%3AassemblyGroupMenu=agmenuform%3AassemblyGroupMenu&data-matrix-treepath=mss_root&agmenuform%3AassemblyGroupMenu_menuid=_c3d3c76c-a976-4d74-a147-db02d56ddb08|4"
 
 	if _, err := c.postRedirect(matrixVersionURL+urlMatrixMainMenu, requestBody); err != nil {
 		return nil
@@ -161,19 +171,28 @@ func (c *MatrixClient) GetEntries() ([]Entry, error) {
 		os.WriteFile("entries.html", []byte(body), os.ModePerm)
 	}
 
-	pattern := regexp.MustCompile(`title="\s*(Uhrzeit \(SZ\)|Time \(ST\)|Time)\s*"\s+class="dateTimeMinuteValue">\s*(\d+):(\d+)\s*</span></td><td role="gridcell" class="tableColumnCenter"><span id="mainbody:editWebBooking:logTable:\d+:logTypeOfBookingTable">([^<]+)</span>`)
+	doc := etree.NewDocument()
+	doc.ReadFromString(body)
+
+	tableData := doc.FindElement("//*[@id='mainbody:editWebBooking:logTable_data']")
+	tableRows := tableData.FindElements("//tr[@data-ri]")
 
 	today := time.Now()
 
-	matches := pattern.FindAllStringSubmatch(body, -1)
+	timeStampRegex := regexp.MustCompile(`\s*(\d+):(\d+)\s*`)
+
 	entries := make([]Entry, 0)
-	for _, m := range matches {
-		if len(m) != 5 {
-			continue
+	for _, row := range tableRows {
+		timeSpan := row.ChildElements()[0].ChildElements()[0]
+		if timeSpan == nil {
+			return nil, fmt.Errorf("could not find time span")
 		}
 
-		hour, _ := strconv.Atoi(m[2])
-		minute, _ := strconv.Atoi(m[3])
+		timeStamp := timeSpan.Text()
+		m := timeStampRegex.FindStringSubmatch(timeStamp)
+
+		hour, _ := strconv.Atoi(m[1])
+		minute, _ := strconv.Atoi(m[2])
 		date := time.Date(today.Year(), today.Month(), today.Day(), hour, minute, 0, 0, time.Local)
 
 		if hour == 0 && minute == 0 {
@@ -181,17 +200,27 @@ func (c *MatrixClient) GetEntries() ([]Entry, error) {
 			continue
 		}
 
-		typeStr := m[4]
+		typeStr := row.ChildElements()[1].ChildElements()[0].Text()
+		typeStr = strings.ToLower(typeStr)
 		var entryType EntryType
-		if strings.Contains(strings.ToLower(typeStr), "kommen") || strings.Contains(strings.ToLower(typeStr), "arrive") || strings.Contains(strings.ToLower(typeStr), "business authorisation") {
+		if strings.Contains(typeStr, "kommen") ||
+			strings.Contains(typeStr, "arrive") ||
+			strings.Contains(typeStr, "business authorisation") {
 			entryType = EntryTypeCome
-		} else if strings.Contains(strings.ToLower(typeStr), "gehen") || strings.Contains(strings.ToLower(typeStr), "leave") || strings.Contains(strings.ToLower(typeStr), "hourly absence - end") || strings.Contains(strings.ToLower(typeStr), "hourly absence end") || strings.Contains(strings.ToLower(typeStr), "system - baend") {
+		} else if strings.Contains(typeStr, "gehen") ||
+			strings.Contains(typeStr, "leave") ||
+			strings.Contains(typeStr, "hourly absence - end") ||
+			strings.Contains(typeStr, "hourly absence end") ||
+			strings.Contains(typeStr, "system - baend") {
+			if strings.Contains(typeStr, "sequence error") {
+				continue
+			}
 			entryType = EntryTypeLeave
-		} else if strings.Contains(strings.ToLower(typeStr), "???bookingtype.1034.name???") {
+		} else if strings.Contains(typeStr, "???bookingtype.1034.name???") {
 			// "???BookingType.1034.name???" wird geschrieben, wenn man am Terminal den Kontostand abfragt
 			verbosePrint("found strange booking type: %q", typeStr)
 			continue
-		} else if strings.Contains(strings.ToLower(typeStr), "valid until") {
+		} else if strings.Contains(typeStr, "valid until") {
 			verbosePrint("found strange booking type: %q", typeStr)
 			continue
 		} else {
@@ -254,8 +283,8 @@ func (c *MatrixClient) postRedirect(url, body string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode != 302 {
-		return "", fmt.Errorf("server returned code %d when 302 was expected", response.StatusCode)
+	if (response.StatusCode < 300) || (399 < response.StatusCode) {
+		return "", fmt.Errorf("server returned code %d when 3xx was expected", response.StatusCode)
 	}
 
 	c.evalCookies(response)


### PR DESCRIPTION
1. Install instructions do now instruct the user to install the latest version of gohome using the @latest tag
2. Compatible with new matrix version
3. Support for sequence errors. 


Sequence Error Example
![image](https://github.com/sbreitf1/gohome/assets/9110370/42db3741-e721-49a8-acc7-4e7ddf5b748f)
