### PR TITLE
Remove trailing newline from entered values

### DIFF
--- a/config.go
+++ b/config.go
@@ -149,6 +149,7 @@ func enterMatrixConfig() (MatrixConfig, error) {
 	if err != nil {
 		return MatrixConfig{}, err
 	}
+	host = strings.TrimSuffix(host, "\n")
 
 	// ensure protocol is appended
 	if !strings.HasPrefix(strings.ToLower(host), "http://") && !strings.HasPrefix(strings.ToLower(host), "https://") {
@@ -164,11 +165,13 @@ func enterMatrixConfig() (MatrixConfig, error) {
 	if err != nil {
 		return MatrixConfig{}, err
 	}
+	user = strings.TrimSuffix(user, "\n")
 
 	pass, err := stdio.ReadPasswordWithPrompt("Pass> ")
 	if err != nil {
 		return MatrixConfig{}, err
 	}
+	stdio.Println("")
 
 	return MatrixConfig{host, user, pass}, nil
 }


### PR DESCRIPTION
This fixes #25 

The function `ReadLineWithPrompt` which is used to ask host,user,pass when starting for the first time, uses `buifio.ReadString` which reads until a newline, but also includes the delimiter in the return value. Therefore the username (and sometimes the host, depending on the format which was entered) will contain a trailing newline, which results in a broken config.json:

```json
{
  "host": "https://XXXXXX",
  "pass": {
    "mode": "aes",
    "data": "XXXXXX"
  },
  "user": "felixb\n"
}
```

Simply trimming trailing newlines will get rid of this.

The empty `Println()` at the end is just an aesthetic fix, because `ReadPasswordWithPromt` won't produce a newline itself, and therefore the first line of actual output will be directly behind the `Pass>` promt.